### PR TITLE
Drop ActiveSupport as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ rvm:
   - 2.3.0
   - ruby-head
   - jruby-19mode
-  - rbx-2
-  - rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ rvm:
   - 2.3.0
   - ruby-head
   - jruby-19mode
+  - jruby-9.0.0.0
+  - jruby-9.1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.2.0
+  - 2.3.0
   - ruby-head
   - jruby-19mode
   - rbx-2
+  - rbx-3

--- a/lib/quick_store/store.rb
+++ b/lib/quick_store/store.rb
@@ -1,4 +1,3 @@
-require 'active_support'
 require 'yaml/store'
 require 'fileutils'
 require 'singleton'
@@ -143,10 +142,26 @@ module QuickStore
 
     def updated_values(old_value, final_value)
       if old_value.is_a?(Hash) && final_value.is_a?(Hash)
-        old_value ? old_value.deep_merge(final_value) : final_value
+        deep_merge(old_value, final_value)
       else
         final_value
       end
+    end
+
+    def deep_merge(old_hash, new_hash)
+      final_hash = old_hash.dup
+
+      new_hash.each_pair do |key, other_value|
+        old_value = final_hash[key]
+
+        if old_value.is_a?(Hash) && other_value.is_a?(Hash)
+          final_hash[key] = deep_merge(old_value, other_value)
+        else
+          final_hash[key] = other_value
+        end
+      end
+
+      final_hash
     end
   end
 end

--- a/quick_store.gemspec
+++ b/quick_store.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '~> 4.0'
-
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'rspec',   '~> 3.0'


### PR DESCRIPTION
The only functionality that was used from ActiveSupport was the Hash#deep_merge method.
Instead of using ActiveSupport the deep_merge functionality is now implemented in the Store class.
